### PR TITLE
instance script execution resource and ecloud credentials data source added

### DIFF
--- a/ecloud/data_source_ecloud_instance_credential.go
+++ b/ecloud/data_source_ecloud_instance_credential.go
@@ -58,15 +58,15 @@ func dataSourceInstanceCredentialsRead(ctx context.Context, d *schema.ResourceDa
 
 	credentials, err := service.GetInstanceCredentials(d.Get("instance_id").(string), params)
 	if err != nil {
-		return diag.Errorf("Error retrieving active instances: %s", err)
+		return diag.Errorf("Error retrieving instance credentials: %s", err)
 	}
 
 	if len(credentials) < 1 {
-		return diag.Errorf("No instances found with provided arguments")
+		return diag.Errorf("No credentials found with provided arguments")
 	}
 
 	if len(credentials) > 1 {
-		return diag.Errorf("More than 1 instance found with provided arguments")
+		return diag.Errorf("More than 1 credential found with provided arguments")
 	}
 
 	d.SetId(credentials[0].ID)

--- a/ecloud/data_source_ecloud_instance_credential.go
+++ b/ecloud/data_source_ecloud_instance_credential.go
@@ -1,0 +1,79 @@
+package ecloud
+
+import (
+	"context"
+
+	"github.com/ans-group/sdk-go/pkg/connection"
+	ecloudservice "github.com/ans-group/sdk-go/pkg/service/ecloud"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceInstanceCredentials() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceCredentialsRead,
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"credential_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceInstanceCredentialsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	service := meta.(ecloudservice.ECloudService)
+
+	params := connection.APIRequestParameters{}
+
+	if username, ok := d.GetOk("username"); ok {
+		params.WithFilter(*connection.NewAPIRequestFiltering("username", connection.EQOperator, []string{username.(string)}))
+	}
+	if credentialID, ok := d.GetOk("credential_id"); ok {
+		params.WithFilter(*connection.NewAPIRequestFiltering("id", connection.EQOperator, []string{credentialID.(string)}))
+	}
+	if name, ok := d.GetOk("name"); ok {
+		params.WithFilter(*connection.NewAPIRequestFiltering("name", connection.EQOperator, []string{name.(string)}))
+	}
+
+	credentials, err := service.GetInstanceCredentials(d.Get("instance_id").(string), params)
+	if err != nil {
+		return diag.Errorf("Error retrieving active instances: %s", err)
+	}
+
+	if len(credentials) < 1 {
+		return diag.Errorf("No instances found with provided arguments")
+	}
+
+	if len(credentials) > 1 {
+		return diag.Errorf("More than 1 instance found with provided arguments")
+	}
+
+	d.SetId(credentials[0].ID)
+	d.Set("instance_id", credentials[0].ResourceID)
+	d.Set("username", credentials[0].Username)
+	d.Set("name", credentials[0].Name)
+	d.Set("password", credentials[0].Password)
+
+	return nil
+}

--- a/ecloud/data_source_ecloud_instance_credential_test.go
+++ b/ecloud/data_source_ecloud_instance_credential_test.go
@@ -1,0 +1,76 @@
+package ecloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceECloudInstanceCreds(t *testing.T) {
+	credName := "root"
+	config := testAccDataSourceECloudInstanceCreds_basic(credName)
+	resourceName := "data.ecloud_instance_credential.root_creds"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", credName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceECloudInstanceCreds_basic(credName string) string {
+	return fmt.Sprintf(`
+data "ecloud_region" "test-region" {
+	name = "Manchester"
+}
+
+resource "ecloud_vpc" "test-vpc" {
+	region_id = data.ecloud_region.test-region.id
+	name = "tftest-vpc"
+}
+
+data "ecloud_availability_zone" "test-az" {
+	name = "Manchester West"
+}
+
+resource "ecloud_router" "test-router-1" {
+  vpc_id               = ecloud_vpc.test-vpc.id
+  availability_zone_id = data.ecloud_availability_zone.test-az.id
+  name                 = "test-router"
+}
+
+resource "ecloud_network" "network-1" {
+	router_id = ecloud_router.test-router-1.id
+	subnet = "10.0.0.0/24"
+}
+
+resource "ecloud_instance" "instance-1" {
+  vcpu {
+    sockets          = 1
+    cores_per_socket = 2
+  }
+  ram_capacity    = 2048
+  vpc_id          = ecloud_vpc.test-vpc.id
+  name            = "instance test"
+  image_id        = "img-19cb94e5"
+  volume_capacity = 40
+  volume_iops     = 600
+  network_id      = ecloud_network.network-1.id
+  backup_enabled  = false
+  encrypted       = false
+}
+
+data "ecloud_instance_credential" "root_creds" {
+  instance_id = ecloud_instance.instance-1.id
+  name        = "%[1]s"
+}
+`, credName)
+}

--- a/ecloud/provider.go
+++ b/ecloud/provider.go
@@ -63,6 +63,7 @@ func Provider() *schema.Provider {
 			"ecloud_resourcetier":        dataSourceResourceTier(),
 			"ecloud_natoverloadrule":     dataSourceNATOverloadRule(),
 			"ecloud_iops":                dataSourceIOPS(),
+			"ecloud_instance_credential": dataSourceInstanceCredentials(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"ecloud_vpc":                   resourceVPC(),
@@ -91,6 +92,7 @@ func Provider() *schema.Provider {
 			"ecloud_affinityrule_member":   resourceAffinityRuleMember(),
 			"ecloud_natoverloadrule":       resourceNATOverloadRule(),
 			"ecloud_volumegroup_instance":  resourceVolumeGroupInstance(),
+			"ecloud_instance_script":       resourceInstanceScript(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/ecloud/resource_instance_script.go
+++ b/ecloud/resource_instance_script.go
@@ -1,0 +1,95 @@
+package ecloud
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	ecloudservice "github.com/ans-group/sdk-go/pkg/service/ecloud"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceInstanceScript() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceScriptCreate,
+		ReadContext:   resourceInstanceScriptRead,
+		DeleteContext: resourceInstanceScriptDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
+			"script": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+	}
+}
+
+func resourceInstanceScriptCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	service := meta.(ecloudservice.ECloudService)
+
+	createReq := ecloudservice.ExecuteInstanceScriptRequest{
+		Script:   d.Get("script").(string),
+		Username: d.Get("username").(string),
+		Password: d.Get("password").(string),
+	}
+	tflog.Debug(ctx, fmt.Sprintf("Created CreateInstanceScriptRequest: %+v", createReq))
+
+	tflog.Info(ctx, "Executing InstanceScript")
+	taskID, err := service.ExecuteInstanceScript(d.Get("instance_id").(string), createReq)
+	if err != nil {
+		return diag.Errorf("Error executing InstanceScript %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%d", rand.Int()))
+
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{ecloudservice.TaskStatusComplete.String()},
+		Refresh:    TaskStatusRefreshFunc(ctx, service, taskID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      10 * time.Second,
+		MinTimeout: 20 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("Error waiting for InstanceScript with ID [%s] to run: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceInstanceScriptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceScriptDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}

--- a/ecloud/resource_instance_script_test.go
+++ b/ecloud/resource_instance_script_test.go
@@ -1,0 +1,100 @@
+package ecloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccInstanceScript(t *testing.T) {
+	scriptResourceName := "ecloud_instance_script.test-script"
+	scriptContent := "hostname"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckIPAddressDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceInstanceScriptConfig_basic(scriptContent),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceScriptExists(scriptResourceName),
+					resource.TestCheckResourceAttr(scriptResourceName, "script", scriptContent),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckInstanceScriptExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Instance ID is set")
+		}
+
+		return nil
+	}
+}
+
+func testAccResourceInstanceScriptConfig_basic(scriptContent string) string {
+	return fmt.Sprintf(`
+data "ecloud_region" "test-region" {
+	name = "Manchester"
+}
+
+resource "ecloud_vpc" "test-vpc" {
+	region_id = data.ecloud_region.test-region.id
+	name = "tftest-vpc"
+}
+
+data "ecloud_availability_zone" "test-az" {
+	name = "Manchester West"
+}
+
+resource "ecloud_router" "test-router-1" {
+  vpc_id               = ecloud_vpc.test-vpc.id
+  availability_zone_id = data.ecloud_availability_zone.test-az.id
+  name                 = "test-router"
+}
+
+resource "ecloud_network" "network-1" {
+	router_id = ecloud_router.test-router-1.id
+	subnet = "10.0.0.0/24"
+}
+
+resource "ecloud_instance" "instance-1" {
+  vcpu {
+    sockets          = 1
+    cores_per_socket = 2
+  }
+  ram_capacity    = 2048
+  vpc_id          = ecloud_vpc.test-vpc.id
+  name            = "instance test"
+  image_id        = "img-19cb94e5"
+  volume_capacity = 40
+  volume_iops     = 600
+  network_id      = ecloud_network.network-1.id
+  backup_enabled  = false
+  encrypted       = false
+}
+
+data "ecloud_instance_credential" "root_creds" {
+  instance_id = ecloud_instance.instance-1.id
+  name        = "root"
+}
+
+resource "ecloud_instance_script" "test-script" {
+  instance_id = ecloud_instance.instance-1.id
+  username = data.ecloud_instance_credential.root_creds.username
+  password = data.ecloud_instance_credential.root_creds.password
+  script = "%[1]s"
+}
+`, scriptContent)
+}


### PR DESCRIPTION
Added code and testing to allow the users to execute scripts on ecloud instances in terraform and retrieve instance credentials.