### PR TITLE
Correct typo

### DIFF
--- a/docs/data-sources/ecloud_instance_credential.md
+++ b/docs/data-sources/ecloud_instance_credential.md
@@ -1,11 +1,11 @@
-# ecloud_credential Data Source
+# ecloud_instance_credential Data Source
 
 This resource represents an eCloud 
 
 ## Example Usage
 
 ```hcl
-data "ecloud_credential" "instance1_root" {
+data "ecloud_instance_credential" "instance1_root" {
   instance_id = "i-abcdef12"
   username = "root"
 }


### PR DESCRIPTION
Correct typo in docs: change `ecloud_credential` to `ecloud_instance_credential`